### PR TITLE
Allow installing packages that depends on isc-dhcp-client

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,7 @@
-isc-dhcp (4.3.5-3cwy1) zesty; urgency=low
-  * Ported raw IP patch from Bjørn Mork.
-  * Renamed package + added conflict.
+isc-dhcp (4.3.5-3cwy2) zesty; urgency=low
+   * Added provides and replaces to allow packages relying on isc-dhcp-client to be installed.
 
- -- Kristian Evensen <kristian.evensen@gmail.com>  Wed, 3 May 2017 09:11:21 +0200
+ -- Jonas Karlsson <jonas.karlsson@kau.se>  Fri, 16 Feb 2018 11:44:23 +0100
 
 isc-dhcp (4.3.5-3ubuntu1) zesty; urgency=low
 

--- a/debian/control
+++ b/debian/control
@@ -113,9 +113,11 @@ Suggests:
  avahi-autoipd,
  isc-dhcp-client-ddns,
 Provides:
- dhcp-client,
+ dhcp-client, isc-dhcp-client,
 Conflicts:
  isc-dhcp-client,
+Replaces: 
+ isc-dhcp-client, 
 Description: DHCP client for automatically obtaining an IP address
  This is the Internet Software Consortium's DHCP client.
  .


### PR DESCRIPTION
To be able to install packages that depends on isc-dhcp-client while still removing orginal isc-dhcp-client I came up with this hack. 
I am no deb maintainer so if there are cleaner ways of doing this please revise.